### PR TITLE
Cioppino text cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Some clarifications
 License
 -------
 
-Copyright © 2010-2011 Plone Foundation and individual contributors.
+Copyright © 2010-2012 Plone Foundation and individual contributors.
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/source/introduction/developermanual.rst
+++ b/source/introduction/developermanual.rst
@@ -23,8 +23,6 @@ This document concerns those who:
 
 * Need to deal with readthedocs.org integration
 
-* wish to upload Sphinx documentation to a Plone site (deprecated)
-
 collective.developermanual
 ==========================
 
@@ -47,18 +45,8 @@ The ``collective.developermanual`` checkout contains
 
 * install Sphinx;
 * compile the manual to HTML;
-* upload manual to a Plone site (using the ``bin/toplone`` script and
-  ``transmogrify`` source packages).
 
-Upload does not need any special support from the Plone site to accept
-Sphinx documentation. If the `Plone Help Center`_ add-on package is
-installed, it will use the *Reference Manual* content types, but in its
-absence the pipeline can be configured to use plain *Folders* and *Pages*
-instead.
-
-.. _Plone Help Center: http://plone.org/products/plonehelpcenter
-
-Setting up software for manual compilation and upload
+Setting up software for manual compilation
 =======================================================
 
 First you need to install Git for your operating system to be able to
@@ -81,7 +69,7 @@ Then clone ``collective.developermanual`` from GitHub::
 
     git clone git://github.com/collective/collective.developermanual.git
 
-Run buildout to install Sphinx and the necessary packages for uploading.
+Run buildout to install Sphinx.
 First step: bootstrap::
 
     python2.6 bootstrap.py
@@ -154,51 +142,6 @@ More info
 
 * https://bitbucket.org/birkenfeld/sphinx/src/65e4c29a24e4/sphinx/themes/basic
 
-Uploading documentation to a Plone site
-------------------------------------------
-
-.. warning :: 
-
-    This part is deprecated; docs are no longer hosted on http://plone.org,
-    but at http://collective-docs.readthedocs.org instead.
-
-The ``collective.developer`` manual contains a buildout which defines a
-pipeline for 
-`collective.transmogrify <http://pypi.python.org/pypi/collective.transmogrifier/>`_
-to upload the Sphinx-generated HTML files to a Plone site as
-`Plone Help Center <http://plone.org/products/plonehelpcenter>`_
-*Reference Manual* content.
-
-``collective.transmogrify`` was originally developed to provide pipelines to
-import, manipulate and export content. It allows you to use a plug-in
-architecture to provide necessary steps, called *blueprints*, to pass
-content in a pipeline from one filter to another.  The idea is very similar
-to video and audio codec architectures.
-
-Blueprints can be mix-and-matched using a ``pipeline.cfg`` configuration
-file.  ``collective.developermanual`` defines pipelines for crawling the
-generated Sphinx HTML files, breaking down the HTML to fields (*title*,
-*description*, *body*) and then uploading it to a Plone site using Zope's
-XML-RPC API and URL functions exposed by Plone.  As Zope provides the
-necessary XML-RPC facilities, no specific code for the uploader is needed on
-the server running the Plone site. 
-
-Setting up a Plone site for receiving Sphinx documentation
------------------------------------------------------------
-
-First install the *Plone Help Center* add-on and create a *Reference Manual* 
-item at the remote site.
-
-The documentation can be uploaded to:
-
-* any Plone site 
-* with
-  `Plone Help Center add-on <http://plone.org/products/plonehelpcenter>`_
-  installed.
-* Sphinx-specific CSS styles can be installed (optional) for source code
-  colorization, warnings, notes and other mark-up in the documentation.
-  These are included as ``sphinx.css`` and it is easiest to drop them to
-  your ``portal_skins`` layer manually.
 
 Compiling the HTML manual
 --------------------------
@@ -210,44 +153,6 @@ Use the Sphinx makefile::
 .. Should this be changed? To the following:
     ./bin/sphinx-build source build
 
-Running upload
---------------
-
-Buildout generates the ``bin/toplone`` command-line script.
-
-Example how to upload to a local Plone instance::
-
-    make clean html
-    ./bin/toplone bin/toplone --ploneupload:target=http://admin:admin@localhost:8080/Plone/documentation/manual/plone-community-developer-documentation
-
-... or in the case of Plone.org::
-
-    ./bin/toplone --ploneupload:target=http://username:password@manage.plone.org/documentation/manual/plone-community-developer-documentation    
-
-(Substitute your username and password in the URL.)
-
-The upload script:
-
-* is generated when you run buildout (see ``buildout.cfg``);
-* reconfigures the transmogrifier pipeline to use the remote site and 
-  *HTTP Basic Auth* credentials provided on the command line;
-* crawls the Sphinx documentation and extracts the title, description and
-  body text of each page (in theory you could crawl any remote web site for
-  this. The ``toplone`` script is created to crawl local documentation
-  only.);
-* create *Plone Help Center* content items at the remote Plone instance
-  using Zope's XML-RPC functionality;
-* update remote Plone items to reflect documentation changes, using Zope's
-  XML-RPC functionality;
-* Publish items, and hide unnecessary items from the navigation (e.g. image
-  source folders).
-
-.. note ::
-
-    The upload script does not currently purge the existing uploaded
-    documentation.  If pages have been renamed or moved, you need to delete
-    the documentation on the target site before performing the upload. Just
-    go to the *Reference Manual Contents* tab, select all, and hit delete.
 
 Setting up CSS for http://plone.org
 -----------------------------------

--- a/source/introduction/preface.rst
+++ b/source/introduction/preface.rst
@@ -2,54 +2,60 @@
 Preface
 =======
 
-Plone and its accompanying technologies have been built over the course of many
-years. The codebase contains over 6000 modules. Even the masterminds don't get
-it always on the first try: over the years, generations of technologies for the
-same function have come and gone, leaving their mark on the code. There are
-technologies which were built when HTTP was just becoming mainstream. There are
-technologies which were built when the Python programming language was still
-young, lacking vast amounts of power and standard library functionality
-available nowadays. Then there are the new trends that influence how things
-should be done, which displace older approaches that may have hit limitations.
+Plone is an open source content management system that lets non-technical people 
+create and maintain web content from their broswer.  With a rich ecosystem of 
+add-on packages and a highly extensible layout system, Plone offers a robust platform
+for those wishing to enhance its core functionality.
 
-The results of hundreds of man-years of code evolution, to develop a
-comprehensive feature set, comes at a price. While Plone tends to cover even
-the most remote corner cases, this comprehensiveness brings complexity, which
-in turn can make simple things unnecessarily difficult.
+Plone has a number of strengths:
 
-Plone is easily one of the most complex Python projects, and no human person
-can master it perfectly. It is not always easy to figure out how everything is
-interacting, especially when there are several ways of doing the same thing.
-There may or may not be good documentation, but due to the vast number of
-possible needs, most of them are uncovered. The documentation itself is
-distributed to the separate domains of knowledge from different ages.
+* Plone enables complex workflows
+* Plone has rich support for internationalization
+* Plone provides clear upgrade paths
+* Plone integrates with Active Directory, Salesforce, LDAP, SQL, Web Services,
+  Oracle (By using Add-on products)
+* Plone scales well
+* Plone will grow with your expanding CMS needs. Many systems will be good
+  for simple sites, but will not be able to handle the expanding requirements 
+  you are likely to encounter over time.
+* Plone is Open Source!
+
+Plone and its accompanying technologies have evolved over the course of many
+years. The codebase contains over 6000 modules. Given the complexity of the
+overall system and large number of optional and included packages, very few
+Plone developers/users know how do everything.
+
+Due to Plone's longevity it has spanned and outlasted some technologies and
+Python practices.  Thus you will see some Python usage which may not match
+todays accepted code practices. You will also see use of Python libraries 
+which are deprecated, and/or implement code where today a standard or 
+optional Python package would be preferred.
+
+Due to Plone's complexity it's important to keep the following in mind:
+
+* Plone has a high level of complexity
+* Plone has more than one way to accomplish many tasks. (Some of which are deprecated)
+* Plone doesn't always have the most complete or up to date documention for all components
 
 When you encounter something you want to get accomplished, but you are unable
-to find direct examples of how to do it, you can resort to the two following
-methods:
+to find direct examples of how to do it, use the following procedure:
 
-* Ask for help. Try the ``#plone`` IRC channel on freenode [1]_ and the
-* product-developers email list [2]_. The help might not arrive instantly.
-  You'll increase chances to get a fellow giving you a helping hand if you can
-  provide very detailed descriptions of your problem. People are also
-  voluntarily helping you; it is not feasible to push them for more they can
-  give for you.
+#. Formulate your question to represent your issue in a way that makes it easy for others to answer [1]_
+#. Search via google and/or stackoverflow
+#. Try the ``#plone`` IRC channel on freenode [2]_ 
+#. Join and send email to the product-developers email list [3]_. 
+#. UTSL (Use The Source Luke). Plone is almost entirely Python code. You can always refer to the source to figure out anything about Plone. Plone source is made up of Python, ZCML, XML, Javascript and Page Template files.
 
-* Search through the codebase. Search references and clues from all the Python,
-  ZCML, XML, Javascript and Page Template files found in the codebase by task
-  keywords. After you find hits, read through the code until you have figured
-  out how all different subsystems interface.
+If you ask the community for help, it may not arrive instantly. Please remember 
+that People are voluntarily helping you. If you need help immediately your best 
+option may be to find paid support for your issues [4]_.
 
 Be patient. Be aware that you are dealing with a complex system and you need to
-reserve time to manage technology and minimize risks. The worst unknowns are
-unknowns you don't know are unknowns. But remember: there are never things you
-cannot do or things you cannot know. There is no black box |---| the codebase is
-all open. With enough patience, you can study it and find solutions to all
-problems. If the stock code does not do it, you can easily monkey-patch the
-existing modules to bend them to your will, or in the most extreme situations
-you can fork the entire project.
+reserve time to manage technology and minimize risks. The community is very supportive and will help you if you make an effort to make it easy for them to do so.
 
-.. [1] http://plone.org/support/chat
-.. [2] http://plone.org/support/forums/addons
+.. [1] http://plone.org/documentation/kb/ask-for-help
+.. [2] http://plone.org/support/chat
+.. [3] http://plone.org/support/forums/addons
+.. [4] http://plone.org/support/providers
 
 .. |---| unicode:: U+02014 .. em dash

--- a/source/tutorials/python.rst
+++ b/source/tutorials/python.rst
@@ -16,7 +16,7 @@ Introduction
 `Python <http://python.org>`_ is the programming language used by 
 `Plone <http://plone.org>`_ and `Zope <http://zope.org>`_.
 
-Tutorial and language learning
+Python Tutorials
 ===============================
 
 * Official Python tutorial: http://docs.python.org/tutorial/


### PR DESCRIPTION
removed reference to bin/toplone which has been removed (jan/8)
Clean up preface.
Other minor cleanup.
