### PR TITLE
Increment Sphinx version 1.1.2 -> 1.1.3

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -56,5 +56,5 @@ zc.recipe.egg=1.2.0
 
 # Some pindowns to make sure Sphinx + dependencies don't go havoc
 collective.recipe.sphinxbuilder = 0.7.0
-Sphinx = 1.1.2
+Sphinx = 1.1.3
 docutils = 0.9


### PR DESCRIPTION
After running buildout and "make html" I got an error in Sphinx
(complete traceback in https://gist.github.com/2691186).
After incrementing to 1.1.3 it disappeared.

 # Sphinx version: 1.1.2
 # Python version: 2.6.5
 # Docutils version: 0.9 release
 # Jinja2 version: 2.5.5
 Traceback (most recent call last):
  File "/home/mazza/.buildout/eggs/Sphinx-1.1.2-py2.6.egg/sphinx/cmdline.py", line 189, in main
    app.build(force_all, filenames)
....
  File "/home/mazza/.buildout/eggs/Sphinx-1.1.2-py2.6.egg/sphinx/util/nodes.py", line 183, in set_role_source_info
    inliner.reporter.locator(lineno)
AttributeError: Reporter instance has no attribute 'locator'
