### PR TITLE
fix broken link

### DIFF
--- a/source/hosting/zopetozeo.rst
+++ b/source/hosting/zopetozeo.rst
@@ -7,7 +7,7 @@ Converting single process instance to ZEO cluster
 Introduction
 ------------
 
-See `ZEO <http://plone.org/documentation/tutorial/installing-plone-3-with-the-unified-installer/to-zeo-or-not-to-zeo>`_.
+See `ZEO <http://plone.org/documentation/manual/installing-plone/installing-on-linux-unix-bsd/to-zeo-or-not-to-zeo>`_.
 
 See the `plone.app.blob product page <http://plone.org/products/plone.app.blob>`
 for good ZEO configuration examples.


### PR DESCRIPTION
The new target link was th only one I found ending with "/to-zeo-or-not-to-zeo".
I guess that is the right one.
