### PR TITLE
Fix list diplay

### DIFF
--- a/source/components/zcml.rst
+++ b/source/components/zcml.rst
@@ -16,10 +16,12 @@ XML-based language used to extend and plug into systems based on the Zope
 Component Architecture (:term:`ZCA`).
 
 It provides:
+
 * conflict resolution (e.g. two plug-ins cannot overlap);
 * extensible syntax based on namespaces.
 
 Downsides of ZCML are: 
+    
 * it is cumbersome to write by hand; 
 * lack of end-user documentation.
 


### PR DESCRIPTION
Hello,

I've made two minor corrections in the ZCML part.

**Problem**

On this page: http://collective-docs.readthedocs.org/en/latest/components/zcml.html

We can see that the two lists `It provides:` and `Downsides of ZCML are:` are not correctly displayed because there is no blank line before the items and the previous line.

**Solution**

I just added the missing blank lines ;)
