### PR TITLE
Fix for: Close too long 2nd level table of contents (#135)

### DIFF
--- a/source/components/index.rst
+++ b/source/components/index.rst
@@ -35,7 +35,7 @@ More info
 * http://www.muthukadan.net/docs/zca.html
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     interfaces
     adapters
@@ -45,7 +45,3 @@ More info
     genericsetup
     events
     customizing_plone
-
-
-
-

--- a/source/content/index.rst
+++ b/source/content/index.rst
@@ -24,7 +24,7 @@ There are two different subsystems to create content objects in Plone
 * Dexterity (Plone 4.x and Plone 3.x)
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     creating
     listing
@@ -32,7 +32,7 @@ There are two different subsystems to create content objects in Plone
     deleting
     rename
     types
-    workflow    
+    workflow
     uid
     ownership
     timestamps

--- a/source/forms/index.rst
+++ b/source/forms/index.rst
@@ -19,16 +19,13 @@ in Content section. This documentation applies only for form libraries.
 Zope 3 schema (zope.schema package) is database-neutral an framework-neutral way to describe Python data models.
 
 .. toctree::
-    :maxdepth: 2
-	
-			
+    :maxdepth: 1
+
     manual
     schemas
     z3c.form
     files
     formlib/index
-    ploneformgen    
+    ploneformgen
     vocabularies
     wysiwyg
-    
-

--- a/source/i18n/index.rst
+++ b/source/i18n/index.rst
@@ -19,11 +19,10 @@ Plone has three different internationalization subsystems:
 
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     internationalisation
     language
     translating_content
     contribute_to_translations
     cache
-

--- a/source/misc/index.rst
+++ b/source/misc/index.rst
@@ -7,7 +7,7 @@ This section describes functions and APIs which are not directly related to any 
 # Managing member profile (portal_membership under site root)
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     context
     datetime
@@ -16,7 +16,7 @@ This section describes functions and APIs which are not directly related to any 
     normalizing_ids
     monkeypatch
     commandline
-    asyncronoustasks    
+    asyncronoustasks
     flowplayer
     navigationtree
     seo

--- a/source/searching_and_indexing/index.rst
+++ b/source/searching_and_indexing/index.rst
@@ -9,7 +9,7 @@ Search keys are matched against the indexed catalog copies to return the indexed
 
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     catalog
     indexing

--- a/source/security/index.rst
+++ b/source/security/index.rst
@@ -11,7 +11,7 @@ Zope provides various built-in security facilities
 * RestrictedPython to evaluate sandboxed code
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     permissions
     permission_lists
@@ -20,5 +20,3 @@ Zope provides various built-in security facilities
     local_roles
     dynamic_roles
     sandboxing
-
-

--- a/source/serving/index.rst
+++ b/source/serving/index.rst
@@ -14,7 +14,7 @@ In Plone, answering to HTTP requests can be divided to three subproblems:
 Plone and Zope 2 application servers support FTP, WebDAV and XML-RPC protocols besides plain HTTP.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    http_request_and_response
    traversing

--- a/source/templates_css_and_javascripts/index.rst
+++ b/source/templates_css_and_javascripts/index.rst
@@ -5,7 +5,7 @@ Templates, CSS and Javascript
 Doing HTML in Plone.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     template_basics
     css
@@ -16,5 +16,3 @@ Doing HTML in Plone.
     xdv
     dtml
     redirects
-
-

--- a/source/testing_and_debugging/index.rst
+++ b/source/testing_and_debugging/index.rst
@@ -5,7 +5,7 @@ Testing and debugging
 This section contains tips how to test and debug your code.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     logging
     pdb
@@ -15,4 +15,3 @@ This section contains tips how to test and debug your code.
     error_log
     boilerplate_tests
     clean_uninstall
-


### PR DESCRIPTION
Here's a set of fixes for the very long tables of contents. I used the "does it put the TOC beneath the fold" test to determine whether to shorten a TOC.
