### PR TITLE
emphasize plone.app.testing

### DIFF
--- a/source/testing_and_debugging/unit_testing.rst
+++ b/source/testing_and_debugging/unit_testing.rst
@@ -126,9 +126,15 @@ Pointers:
 
 * http://plone.org/documentation/kb/testing
 
+* http://pypi.python.org/pypi/plone.app.testing
+
 * http://pypi.python.org/pypi/Products.PloneTestCase
 
 * http://www.zope.org/Members/shh/ZopeTestCaseWiki/ApiReference
+
+
+For new test suites, it is recommended to use `plone.app.testing`.
+
 
 Base test class skeleton
 ========================


### PR DESCRIPTION
Imho, new users should be directed to look at plone.app.testing right from the start. But since I don't know whether you approve of this, I submit the change via pull request, instead of committing directly.
Enjoy!
