### PR TITLE
Sphinx plone.css modified to format #editor-trap nicely when printing.

### DIFF
--- a/source/_static/plone.css
+++ b/source/_static/plone.css
@@ -128,7 +128,28 @@ a:visited:hover {
 
 /* ... hide editor trap when printing ... */
 @media print {
-#editor-trap { display: none }
+    #editor-trap {
+        /* display: none;*/
+        margin: 0;
+        padding: 0;
+        box-shadow: none;
+        width: 80%;
+        position: relative;
+        border: none;
+
+       -moz-transform: rotate(0deg);
+        -webkit-transform: rotate(0deg);
+        -o-transform: rotate(0deg);
+        -ms-transform: rotate(0deg);
+        transform: rotate(0deg);
+        box-shadow: none;
+        -moz-box-shadow: none;
+        -webkit-box-shadow: none;
+    }
+    #editor-trap.toggled > * {
+        display: block;
+    }
+
 }
 
 /* Special classes on doc front page */

--- a/source/_static/plone.css
+++ b/source/_static/plone.css
@@ -126,6 +126,11 @@ a:visited:hover {
     display: block;
 }
 
+/* ... hide editor trap when printing ... */
+@media print {
+#editor-trap { display: none }
+}
+
 /* Special classes on doc front page */
 #dragon-warning {
     padding: 1em;

--- a/source/functionality/portlets.rst
+++ b/source/functionality/portlets.rst
@@ -16,7 +16,7 @@ Add-ons allow portlets in other parts in of the user interface too, like
 above and below the content.
 
 This document is contains quick how-to information only.
-Please visit :doc`Portlets reference manual </reference_manuals/portlets/index>`
+Please visit :doc:`Portlets reference manual </reference_manuals/old/portlets/index>`
 for in-depth information.
 
 Related add-ons and packages

--- a/source/functionality/portlets.rst
+++ b/source/functionality/portlets.rst
@@ -492,7 +492,7 @@ from zope.component import getUtility, getMultiAdapter, queryMultiAdapter
 
         return html
 
-How to use this code in your own view, please see `collective.portletalias source <https://github.com/collective/collective.portletalias/blob/master/collective/portletalias/portlets/aliasportlet.py#L73>`_ 
+How to use this code in your own view, please see `collective.portletalias source <https://github.com/collective/collective.portletalias/blob/master/collective/portletalias/portlets/aliasportlet.py#L73>`_
 
 More info
 
@@ -520,7 +520,7 @@ Example portlets.xml::
   <portlet addview="collective.flowplayer.Player" remove="true" />
 
 
-Portlet na,es can be found in ``plone.app.portlets/configure.zcml``.
+Portlet names can be found in ``plone.app.portlets/configure.zcml``.
 
 More info:
 


### PR DESCRIPTION
I like the editor-trap annoyance object ;-) Nevertheless it leads me to this change for printing, because sometimes the box overlaps significant stuff. And on EVERY page! 

My initial tag fix1.0 simply hided the #editor-trap.

But during writing the pull request I decided of adding a printer friendly formatting of the box content at the end of the page.

So there is tag fix1.1 for this!

May the documentation force be with us! Avoid printing! But when necessary be smart!
