### PR TITLE
Add installing addons page to getting started.

### DIFF
--- a/source/getstarted/index.rst
+++ b/source/getstarted/index.rst
@@ -76,6 +76,17 @@ Using Buildout involves using the ``buildout.cfg`` configuration file and the ``
   standard Python packages, managed by Buildout.
 
 
+Finding and installing add-on packages
+--------------------------------------
+
+Plone add-ons can be found at the `plone.org Products
+<http://plone.org/products>`_ page or at the  `PyPI (the Python
+Package index) <http://pypi.python.org>`_.
+
+See the :doc:`Installing add-on packages using buildout
+</getstarted/installing_addons>` section for more details.
+
+
 Creating your first add-on
 ----------------------------
 
@@ -185,6 +196,7 @@ More info
 
     installation
     debug_mode
+    installing_addons
     python
     paste
     /reference_manuals/active/helloworld/index
@@ -213,4 +225,3 @@ Zope resources
 
   The chapters on Zope Page Templates however are still the best reference
   on the topic.
-

--- a/source/getstarted/installing_addons.rst
+++ b/source/getstarted/installing_addons.rst
@@ -1,0 +1,138 @@
+=========================================
+Installing add-on packages using buildout
+=========================================
+
+
+.. contents:: :local:
+
+
+Introduction
+------------
+
+Plone uses `Buildout <http://www.buildout.org/>`_ for installing add-on packages.
+See :doc:`installation instructions </getstarted/installation>` for
+how to create a Plone installation suitable for development.
+
+
+Discovering Plone add-ons and other python packages
+---------------------------------------------------
+
+The `plone.org Products <http://plone.org/products>`_ is a directory
+of Plone add-on packages where a lot of add-on packages for Plone are
+listed.
+
+A lot more packages can be found in the `PyPI (the Python Package
+index) <http://pypi.python.org>`_, although most of the packages might
+not be Plone specific.
+
+
+Installing add-ons using buildout
+---------------------------------
+
+Add-on packages which are uploaded to `PyPI <http://pypi.python.org>`_
+or `plone.org <http://plone.org/products>`_ as *egg* can be installed
+by buildout.
+
+Edit your `buildout.cfg` file and add the add-on package to the list
+of eggs:
+
+.. code:: ini
+
+    [buildout]
+    ...
+    eggs =
+        ...
+        Products.PloneFormGen
+        solgema.fullcalendar
+
+.. note ::
+
+    The above example works for the buildout created by the unified
+    installer. If you however have a custom buildout you might need to
+    add the egg to the *eggs* list in the *[instance]* section rather
+    than adding it in the *[buildout]* section.
+
+
+For the changes to take effect you need to re-run buildout from your
+console:
+
+.. code:: console
+
+    bin/buildout -N
+
+
+.. note ::
+
+    The `-N` argument tells buildout to not update already installed
+    packages even when there is a newer version.
+
+Finally, you might want to restart your instance for the changes to
+take effect:
+
+.. code:: console
+
+    bin/instance restart
+
+
+Installing development version of add-on packages
+-------------------------------------------------
+
+If you need to use the latest development version of an add-on package
+you can easily get the source in your development installation using
+the buildout extension `mr.developer
+<http://pypi.python.org/pypi/mr.developer>`_.
+
+.. note::
+
+    It is not recommended to run a production environment with
+    development / source versions of add-on packages. They might
+    unexpectedly change or be temprorary broken.
+
+For managing the sources it is recommended to create a `sources.cfg`
+which you can include in your buildout.
+
+.. code:: ini
+
+    [buildout]
+    extends = http://plonesource.org/sources.cfg
+    extensions = mr.developer
+
+    auto-checkout =
+        Products.PloneFormGen
+        solgema.fullcalendar
+
+Adding add-on package names to the **auto-checkout** list will make
+buildout check out the source to the `src` directory upon next
+buildout run.
+
+.. note ::
+
+    It is not recommended to use `auto-checkout = *`, especially when
+    you extend from a big list of sources, such as the plonesource.org
+    list.
+
+.. note ::
+
+    The `auto-checkout` option only checks out the source. It is also
+    required to add the package to the `eggs` list for getting it
+    installed, see above.
+
+After creating a `sources.cfg` you need to make sure that it gets
+loaded by the `buildout.cfg`. This is done by adding it to the
+`extends` list in your `buildout.cfg`:
+
+.. code:: ini
+
+    [buildout]
+    extends =
+        base.cfg
+        versions.cfg
+        sources.cfg
+
+As always: after modifying the buildout configuration you need to
+rerun buildout and restart your instance:
+
+.. code:: console
+
+    bin/buildout -N
+    bin/instance restart


### PR DESCRIPTION
I could only find the old [Installing a third party product](http://developer.plone.org/reference_manuals/old/buildout/thirdparty.html) page so a wrote an updated / shorter one.
- I think `mr.developer` should be used and packages should not be cloned manually and added to `develop` in buildout.
- I didn't cover old school Products, since most up to date add-ons are distributed as egg.
- I dropped all the ZCML stuff, since most of the add-ons have a `z3c.autoinclude` entry point nowadays.

I recently started the [plonesource.org](http://plonesource.org) project (sources for mr.developer) and was threatened to be thrown in a cold swimming pool unless I document plonesource.org here :open_mouth:
That's why I've used plonesource.org in the `sources.cfg` example, although I'm not sure whether it belongs there or should be moved to the `external` or `reference_manuals` parts. Feel free to place your opinion and I'm happy to update my pull-request :wink: 

When the PR is merged I'll also update plonesource.org and add a link to the developer manual.
