### PR TITLE
remove warning about add_view_expr.  It's not true

### DIFF
--- a/source/content/dexterity.rst
+++ b/source/content/dexterity.rst
@@ -294,13 +294,6 @@ You can register such an adapter in ``configure.zcml``
 
     </configure>
 
-.. warning::
-
-    Overriding ``add_view_expr`` or ``add_view_expr_object`` in Dexterity
-    factory type information, so that they directly link to a view provided,
-    is not possible. You can manually type :guilabel:`Add view link` in
-    ``portal_types``, but setting it through :term:`GenericSetup` installer
-    code is not possible.
 
 Then you can inherit from the proper ``plone.dexterity`` base classes::
 


### PR DESCRIPTION
Since p.dexterity version 1.0.1 it has been possible to set a custom `add_view_expr` via the fti GenericSetup xml for dexterity content types.  See https://github.com/plone/plone.dexterity/commit/d718da19526f7ef6a713995aef88ed25242a65f3
