### PR TITLE
Enable proxy_http

### DIFF
--- a/source/hosting/apache.rst
+++ b/source/hosting/apache.rst
@@ -26,6 +26,7 @@ Install required software::
 	sudo apt-get install apache2
 	sudo a2enmod rewrite
 	sudo a2enmod proxy
+	sudo a2enmod proxy_http
         sudo /etc/init.d/apache2 restart
 
 Add virtual host config file ``/etc/apache2/sites-enabled/yoursite.conf``.


### PR DESCRIPTION
Add proxy_http for modules to enable in Apache2.  Without it, Apache will return an internal error on rewrites.
