### PR TITLE
replace deprecated aliases with the correct method names

### DIFF
--- a/source/content/workflow.rst
+++ b/source/content/workflow.rst
@@ -230,7 +230,7 @@ Useful to test if a particular workflow is installed::
 
   # Get all site workflows
   ids = workflowTool.getWorkflowIds()
-  self.failUnless("link_workflow" in ids, "Had workflows " + str(ids))
+  self.assertIn('link_workflow', ids, "Had workflows " + str(ids))
 
 Getting default workflow for a portal type
 ===============================
@@ -238,7 +238,7 @@ Getting default workflow for a portal type
 Get default workflow for the type::
 
  chain = workflowTool.getChainForPortalType(ExpensiveLink.portal_type)
- self.failUnless(chain == ("link_workflow",), "Had workflow chain" + str(chain))
+ self.assertEqual(chain, ('link_workflow',), "Had workflow chain" + str(chain))
 
 Getting workflows for an object
 ===============================
@@ -251,10 +251,10 @@ How to test which workflow the object has::
     chain = workflowTool.getChainFor(context)
 
     # there must be only one workflow for our object
-    self.failUnless(len(chain) == 1)
+    self.assertEqual(len(chain), 1)
 
     # this must must be the workflow name
-    self.failUnless(chain[0] == 'link_workflow', "Had workflow " + str(chain[0]))
+    self.assertEqual(chain[0], 'link_workflow', "Had workflow " + str(chain[0]))
 
 
 Via HTTP

--- a/source/reference_manuals/old/archetypes/a_simple_at_product/basic_integration_tests.rst
+++ b/source/reference_manuals/old/archetypes/a_simple_at_product/basic_integration_tests.rst
@@ -82,13 +82,13 @@ The actual tests are in “test\_setup.py”:
 
         def testTypesInstalled(self):
             for t in self.types:
-                self.failUnless(t in self.portal.portal_types.objectIds(),
-                                '%s content type not installed' % t)
+                self.assertIn(t, self.portal.portal_types.objectIds(),
+                              '%s content type not installed' % t)
 
         def testPortalFactoryEnabled(self):
             for t in self.types:
-                self.failUnless(t in self.portal.portal_factory.getFactoryTypes().keys(),
-                                '%s content type not installed' % t)
+                self.assertIn(t, self.portal.portal_factory.getFactoryTypes().keys(),
+                              '%s content type not installed' % t)
 
     class TestInstantiation(InstantMessageTestCase):
 
@@ -98,11 +98,11 @@ The actual tests are in “test\_setup.py”:
             self.portal.invokeFactory('InstantMessage', 'im1')
 
         def testCreateInstantMessage(self):
-            self.failUnless('im1' in self.portal.objectIds())
+            self.assertIn('im1', self.portal.objectIds())
 
         def testInstantMessageInterface(self):
             im = self.portal.im1
-            self.failUnless(IInstantMessage.providedBy(im))
+            self.assertTrue(IInstantMessage.providedBy(im))
 
     def test_suite():
         from unittest import TestSuite, makeSuite

--- a/source/reference_manuals/old/testing/writing_ptc_test.rst
+++ b/source/reference_manuals/old/testing/writing_ptc_test.rst
@@ -168,11 +168,11 @@ The test class which uses this environment is found in tests/test_integration_un
             #   - self.logout() "logs out" so that the user is Anonymous
             #   - self.setRoles(['Manager', 'Member']) adjusts the roles of the current user
 
-            self.assertEquals("Plone site", self.portal.getProperty('title'))
+            self.assertEqual("Plone site", self.portal.getProperty('title'))
 
         def test_able_to_add_document(self):
             new_id = self.folder.invokeFactory('Document', 'my-page')
-            self.assertEquals('my-page', new_id)
+            self.assertEqual('my-page', new_id)
 
         # Keep adding methods here, or break it into multiple classes or
         # multiple files as appropriate. Having tests in multiple files makes
@@ -199,7 +199,7 @@ You are free to add whatever helper methods you wish to your unit test class, bu
 method with a name starting with test will be executed as a test. Tests are usually
 written to be as concise (not to be confused with "obfuscated") as possible.
 
-Notice the calls to methods like self.assertEqual() or self.failUnless(). These are
+Notice the calls to methods like self.assertEqual() or self.assertTrue(). These are
 the assertion methods that do the actual testing. If any of these fail, that test is
 counted as a failure and you'll get an ugly F in your test output.
 
@@ -241,7 +241,7 @@ if something is True or False. Having a variety of names allows you to make your
 the way you want. The list of assertion methods can be found in the Python documentation
 for unittest.TestCase. The most common ones are:
 
-failUnless(expr)
+assertTrue(expr)
     Ensure expr is true
 assertEqual(expr1, expr2)
     Ensure expr1 is equal to expr2

--- a/source/testing_and_debugging/boilerplate_tests.rst
+++ b/source/testing_and_debugging/boilerplate_tests.rst
@@ -12,7 +12,7 @@ to learn about PloneTestCase helper methods.
 Test portal title::
 
     def test_portal_title(self):
-        self.assertEquals("Plone site", self.portal.getProperty('title'))
+        self.assertEqual("Plone site", self.portal.getProperty('title'))
 
 
 Test if view is protected::
@@ -29,7 +29,7 @@ Test if view is protected::
 Test if object exists in folder::
 
     def test_object_in_folder(self):
-        self.failIf('object_id' in self.portal.objectIds())
+        self.assertNotIn('object_id', self.portal.objectIds())
 
 
 Javascript registered::
@@ -37,7 +37,7 @@ Javascript registered::
     def test_js_available(self):
         jsreg = getattr(self.portal, 'portal_javascripts')
         script_ids = jsreg.getResourceIds()
-        self.failUnless('my-js-file.js' in script_ids)
+        self.assertIn('my-js-file.js', script_ids)
 
 
 CSS registered::
@@ -45,12 +45,12 @@ CSS registered::
     def test_css_available(self):
         cssreg = getattr(self.portal, 'portal_css')
         stylesheets_ids = cssreg.getResourceIds()
-        self.failUnless('MyCSS.css' in stylesheets_ids)
+        self.assertIn('MyCSS.css', stylesheets_ids)
 
 
 Test that a certain skin layer is present in portal_skins::
 
     def test_skin_layer_installed(self):
-        self.failUnless('my-skin-layer' in self.skins.objectIds())
-        self.failUnless('attachment_widgets' in self.skins.objectIds()) 
+        self.assertIn('my-skin-layer', self.skins.objectIds())
+        self.assertIn('attachment_widgets', self.skins.objectIds())
 

--- a/source/views/viewlets.rst
+++ b/source/views/viewlets.rst
@@ -979,7 +979,7 @@ Occasionaly, you may need to get hold of your viewlets in python code, perhaps i
 
             # viewlet managers are found by Multi-Adapter lookup
             manager = queryMultiAdapter((context, request, view), IViewletManager, manager_name, default=None)
-            self.failUnless(manager)
+            self.assertIsNotNone(manager)
 
             # calling update() on a manager causes it to set up its viewlets
             manager.update()
@@ -989,7 +989,7 @@ Occasionaly, you may need to get hold of your viewlets in python code, perhaps i
             # to register the viewlet in zcml
             my_viewlet = [v for v in manager.viewlets if v.__name__ == 'mypackage.myviewlet']
 
-            self.failUnlessEqual(len(my_viewlet), 1)
+            self.assertEqual(len(my_viewlet), 1)
 
 Since it is possible to register a viewlet for a specific content type and for
 a browser layer, you may also need to use these elements in looking up your


### PR DESCRIPTION
see http://docs.python.org/2/library/unittest.html#deprecated-aliases for more information
