### PR TITLE
update class name in configure.zcml full example

### DIFF
--- a/source/reference_manuals/active/helloworld/extend/view.rst
+++ b/source/reference_manuals/active/helloworld/extend/view.rst
@@ -53,7 +53,7 @@ If you also went through the simple form tutorial, then *configure.zcml* should 
         <browser:page
             name="hello_world_form"
             for="*"
-            class=".hello.HelloWorldFormView"
+            class=".hello_world_form.HelloWorldFormView"
             permission="zope2.View"
             />
         


### PR DESCRIPTION
The docs refer to the 'simple form' tutuorial, which used the name 'hello_world_form' for the python module.  This page should show the same module name in configure.zcml.
