### PR TITLE
Tip for adding custom headers on tests

### DIFF
--- a/source/serving/http_request_and_response.rst
+++ b/source/serving/http_request_and_response.rst
@@ -173,9 +173,8 @@ Example::
 
         return ip
 
-For more information, see:
-
-* http://wiki.zope.org/zope2/ZopeAndApache#setting-remote-addr-to-the-client-ip
+For functional tests based on ``zope.testbrowser`` use the ``addHeader`` method
+to add custom headers to a browser.
 
 ``GET`` variables
 -----------------


### PR DESCRIPTION
Explain how to add custom headers for tests based on zope.testbrowser.

Removed a dead link as a bonus.

As I had to do some tests that need custom headers set on requests I realized that the documentation here was not so up to date, so I took the time to update it :)
