### PR TITLE
Added reference to additional lib packages.

### DIFF
--- a/source/getstarted/ubuntu_production.rst
+++ b/source/getstarted/ubuntu_production.rst
@@ -45,7 +45,7 @@ Then, install the platform's build kit, nginx, and supervisor:
 .. code-block:: console
 
     sudo apt-get install build-essential python-dev libjpeg-dev libxslt-dev supervisor nginx
-
+    
 Step 2: Install Plone
 ---------------------
 
@@ -73,6 +73,8 @@ This will install Plone to /usr/local/Plone. There are installer options to put 
 
     This creates a `zeo` installation with two Plone clients. We will only connect one of those clients to the Internet. The other will be reserved for debugging and administrator access. If you know this is a larger site and wish to use load balancing, you may create more clients with the `--clients=##` command-line argument to create more clients. They're also easy to add later.
 
+If you hit an "lxml" error during installation (ie the log shows "Error: Couldn't install: lxml 2.3.6") you may need additional libraries.
+Take a look at http://plone.org/documentation/manual/installing-plone/installing-on-linux-unix-bsd/debian-libraries 
 
 When the install completes, you'll be shown the preset administrative password. Record it. If you lose it, you may see it again:
 


### PR DESCRIPTION
Added a reference to http://plone.org/documentation/manual/installing-plone/installing-on-linux-unix-bsd/debian-libraries 
Installing the referenced packages allowed my buildout to succeed on DigitalOcean Ubuntu 13 droplet.
