### PR TITLE
Don't echo on no-op runs

### DIFF
--- a/doc-holliday.sh
+++ b/doc-holliday.sh
@@ -29,6 +29,4 @@ if [[ ! -z "$changed" ]] ; then
     install -d $deploy_target
     rsync -a --inplace build/html/* $deploy_target
     echo "Copied docs to $deploy_target"
-else
-    echo "Git was up to date - no docs built"
 fi


### PR DESCRIPTION
Every time a cron job writes to stdout on success, a UNIX admin trims his beard. Won't someone think of the beards?!

Seriously, this script runs from cron every 5 minutes, and we get every one of those echos as an email to root@. No more!
